### PR TITLE
Add left/right inner/outer/full joins

### DIFF
--- a/__tests__/SelectTest.re
+++ b/__tests__/SelectTest.re
@@ -77,6 +77,41 @@ describe("from", () => {
         |> innerJoin("tbl2 as t2", "t2.id", "=", "t.id")
         |> evaluate({|select * from "tbl" as "t" inner join "tbl2" as "t2" on "t2"."id" = "t"."id"|})
     );
+
+    test("leftJoin", () =>
+        mk()
+        |> from("tbl")
+        |> leftJoin("tbl2", "tbl2.id", "=", "tbl.id")
+        |> evaluate({|select * from "tbl" left join "tbl2" on "tbl2"."id" = "tbl"."id"|})
+    );
+
+    test("leftOuterJoin", () =>
+        mk()
+        |> from("tbl")
+        |> leftOuterJoin("tbl2", "tbl2.id", "=", "tbl.id")
+        |> evaluate({|select * from "tbl" left outer join "tbl2" on "tbl2"."id" = "tbl"."id"|})
+    );
+
+    test("rightJoin", () =>
+        mk()
+        |> from("tbl")
+        |> rightJoin("tbl2", "tbl2.id", "=", "tbl.id")
+        |> evaluate({|select * from "tbl" right join "tbl2" on "tbl2"."id" = "tbl"."id"|})
+    );
+
+    test("rightOuterJoin", () =>
+        mk()
+        |> from("tbl")
+        |> rightOuterJoin("tbl2", "tbl2.id", "=", "tbl.id")
+        |> evaluate({|select * from "tbl" right outer join "tbl2" on "tbl2"."id" = "tbl"."id"|})
+    );
+
+    test("fullOuterJoin", () =>
+        mk()
+        |> from("tbl")
+        |> fullOuterJoin("tbl2", "tbl2.id", "=", "tbl.id")
+        |> evaluate({|select * from "tbl" full outer join "tbl2" on "tbl2"."id" = "tbl"."id"|})
+    );
 });
 
 describe("where", () => {

--- a/src/Knex.rei
+++ b/src/Knex.rei
@@ -62,6 +62,11 @@ module Select: {
 
     let from: (~alias: Js.Dict.key=?, string, t('a)) => t('a);
     let innerJoin: (string, string, string, string, t('a)) => t('a);
+    let leftJoin: (string, string, string, string, t('a)) => t('a);
+    let leftOuterJoin: (string, string, string, string, t('a)) => t('a);
+    let rightJoin: (string, string, string, string, t('a)) => t('a);
+    let rightOuterJoin: (string, string, string, string, t('a)) => t('a);
+    let fullOuterJoin: (string, string, string, string, t('a)) => t('a);
 
     let groupBy: (string, t('a)) => t('a);
 

--- a/src/Select.re
+++ b/src/Select.re
@@ -24,6 +24,11 @@ let from = (~alias=?, table) =>
 [@bs.send.pipe: t('a)] external limit: int => t('a) = "";
 
 [@bs.send.pipe: t('a)] external innerJoin : string => string => string => string => t('a) = "";
+[@bs.send.pipe: t('a)] external leftJoin : string => string => string => string => t('a) = "";
+[@bs.send.pipe: t('a)] external leftOuterJoin : string => string => string => string => t('a) = "";
+[@bs.send.pipe: t('a)] external rightJoin : string => string => string => string => t('a) = "";
+[@bs.send.pipe: t('a)] external rightOuterJoin : string => string => string => string => t('a) = "";
+[@bs.send.pipe: t('a)] external fullOuterJoin : string => string => string => string => t('a) = "";
 
 [@bs.send.pipe: t('a)] external groupBy : string => t('a) = "";
 

--- a/src/Select.rei
+++ b/src/Select.rei
@@ -8,6 +8,11 @@ let countDistinct: (string, t('a)) => t('a);
 
 let from: (~alias: Js.Dict.key=?, string, t('a)) => t('a);
 let innerJoin: (string, string, string, string, t('a)) => t('a);
+let leftJoin: (string, string, string, string, t('a)) => t('a);
+let leftOuterJoin: (string, string, string, string, t('a)) => t('a);
+let rightJoin: (string, string, string, string, t('a)) => t('a);
+let rightOuterJoin: (string, string, string, string, t('a)) => t('a);
+let fullOuterJoin: (string, string, string, string, t('a)) => t('a);
 
 let groupBy: (string, t('a)) => t('a);
 


### PR DESCRIPTION
Currently `bs-knex` provides bindings only for the inner join. This PR adds the rest.